### PR TITLE
Use a prompt to generate more human commit messages

### DIFF
--- a/autocommit.js
+++ b/autocommit.js
@@ -37,11 +37,11 @@ const configuration = new Configuration({
 const openai = new OpenAIApi(configuration);
 
 // create a prompt
-const prompt = `Read the following git diff for a multiple files:
+const prompt = `Given the following git diff(s):
 
 ${diff}
 
-Generate a commit message to explain diff in each file:
+Write a human Git commit message with title (no quotes!) to explain the change:
 
 `;
 
@@ -60,7 +60,7 @@ openai
     stop: ["\n\n\n"],
   })
   .then((data) => {
-    const commitMessage = data.data.choices[0].text;
+    const commitMessage = data.data.choices[0].text.trim();
     const command = `git add --all && git commit -m "${commitMessage.replace(/"/g, '\\"')}"`;
 
     if (!process.env.GIT_AI_AUTOCOMMIT) {


### PR DESCRIPTION
The old version generates a **list** (1,2,3,...) of detailed changes. This is often very unhelpful, because the Changes page has a much better view. What you really want is a short, humanly-like written summary of what has changed.

This new prompt from my testing tends to write a much more human title and commit message, which is a significant step-up of usability in real projects.