### PR TITLE
Allow user to request being asked to regenerate 

### DIFF
--- a/autocommit.js
+++ b/autocommit.js
@@ -84,6 +84,7 @@ function generatePrompt() {
           output: process.stdout
         });
         input.question(`Commit with the above message? [y/r/N]: `, (answer) => {
+          input.close();
           if (answer.match(/^(y|Y)$/)) {
             console.log(`Committing with following command:\n ${command}`);
             execSync(command, {encoding: 'utf8'});
@@ -92,7 +93,6 @@ function generatePrompt() {
           } else {
             console.log("Not committing.");
           }
-          input.close();
         });
       }
 


### PR DESCRIPTION
This add a 3rd option, "ask", in addition to "1/true" and "0/false", where the user will be asked whether they are happy with the current message, or wishes to regenerate. This increases user-friendliness, because allows you to still be lazy by not having to write commit messages, but also catch the 1% of the time where OpenAI will throw something weird or malformed.