### PR TITLE
Added support for rc files and cli arguments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 OPENAI_API_KEY=
-GIT_AI_COMMIT_CONFIG_NAME=.git-ai-commit-config.js

--- a/README.md
+++ b/README.md
@@ -14,10 +14,23 @@ npm install -g git-aicommit
 
 ## Configuration
 
-This cli tool uses configuration file located where `GIT_AI_COMMIT_CONFIG_NAME` points at,
-defaults to `~/.git-ai-commit-config.js`.
+This cli tool uses [standard rc files](https://www.npmjs.com/package/rc#standards):
+
+- local `.git-aicommitrc`
+- `$HOME/.git-aicommitrc`
+- `$HOME/.git-aicommit/config`
+- `$HOME/.config/git-aicommit`
+- `$HOME/.config/git-aicommit/config`
+- `/etc/git-aicommitrc`
+- `/etc/git-aicommit/config`
 
 Or [default config](config.js) is used if no config file is found.
+
+### Command line arguments
+
+```bash
+git-aicommit --openAiKey="sk-..." --completionPromptParams.temperature=0.3 --no-autocommit
+```
 
 ## Usage
 

--- a/autocommit.js
+++ b/autocommit.js
@@ -3,12 +3,9 @@
 require('dotenv').config();
 const {Configuration, OpenAIApi} = require("openai");
 const {execSync, spawn} = require("child_process");
+const rc = require('rc');
 
-const os = require('os');
-const fs = require('fs');
-
-const configFilename = process.env.GIT_AI_COMMIT_CONFIG_NAME || '.git-ai-commit-config.js';
-const configPath = os.homedir() + '/' + configFilename;
+const defaultConfig = require('./config.js');
 
 // if (!fs.existsSync(configPath)) {
 //     TODO: param to create default config file
@@ -18,7 +15,7 @@ const configPath = os.homedir() + '/' + configFilename;
 //     console.log(`Created default config file at ${configPath}`);
 // }
 
-const config = !fs.existsSync(configPath) ? require('./config.js') : require(configPath);
+const config = rc('git-aicommit', defaultConfig);
 
 try {
   execSync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-aicommit",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Generates auto commit messages with OpenAI GPT3 model",
   "main": "autocommit.js",
   "repository": "https://github.com/shanginn/autocommit",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.0.2",
-    "openai": "^3.0.0"
+    "openai": "^3.0.0",
+    "rc": "1.2.8"
   },
   "preferGlobal": true,
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -45,6 +50,11 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -57,6 +67,11 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
+minimist@^1.2.0:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 openai@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/openai/-/openai-3.0.0.tgz#0816f1d72ee37820c9ff14d93d597431489fec37"
@@ -64,3 +79,18 @@ openai@^3.0.0:
   dependencies:
     axios "^0.26.0"
     form-data "^4.0.0"
+
+rc@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==


### PR DESCRIPTION
Implementation of a standard way to search for configuration files

- local `.git-aicommitrc`
- `$HOME/.git-aicommitrc`
- `$HOME/.git-aicommit/config`
- `$HOME/.config/git-aicommit`
- `$HOME/.config/git-aicommit/config`
- `/etc/git-aicommitrc`
- `/etc/git-aicommit/config`

[More details](https://www.npmjs.com/package/rc#standards)

Also added the ability to use cli arguments, e.g.

```bash
git-aicommit --openAiKey="sk-..." --completionPromptParams.temperature=0.3 --no-autocommit 
```

**BREAKING CHANGES**

`.git-ai-commit-config.js` is no longer in use